### PR TITLE
Fix admin creation

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -52,6 +52,8 @@ ram.runtime = "50M"
 
     [install.admin]
     type = "user"
+    help.en = "The user's main email address will be used for login, not their username."
+    help.fr = "L'adresse email principale de ce compte sera utilisée pour la connexion, le nom de compte ne fonctionnera pas."
 
     [install.password]
     type = "password"

--- a/scripts/install
+++ b/scripts/install
@@ -55,10 +55,9 @@ ynh_local_curl "/?ctrl=offline&action=install&disconnect=1" \
     "db_password=$db_pwd" \
     "adminName=$admin_lastname" \
     "adminFirstName=$admin_firstname" \
-    "adminLogin=$admin" \
+    "adminMailLogin=$admin_mail" \
     "adminPassword=$password" \
     "adminPasswordVerif=$password" \
-    "adminMail=$admin_mail" \
     "spaceName=YunoHost" \
     "spaceDescription=YunoHost" \
     "spacePublic=0" \


### PR DESCRIPTION
Closes #12 

There is no "adminLogin" field anymore, only "adminMailLogin". Let's also add a mention that the user is not used, only the email.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
