### PR TITLE
Upgrade to 26.2

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -79,6 +79,8 @@ ram.runtime = "50M"
         "php8.3-fpm",
         "php8.3-imagick",
         "php8.3-mysql",
+        "php8.3-intl",
+        "php8.3-mbstring",
         "mariadb-server",
     ]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Agora"
 description.en = "Collaboration and creation of digital space"
 description.fr = "Collaboration et création d'espace numérique"
 
-version = "26.2~ynh1"
+version = "26.2~ynh2"
 
 maintainers = ["frju365"]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -66,18 +66,6 @@ ram.runtime = "50M"
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset = "tarball"
     
-    [resources.sources.install]
-    url = "https://github.com/xech/agora-project/releases/download/25.12/INSTALL_agora-project_25.12.4.zip"
-    sha256 = "5d7856ee32bea6fe4a77c8bc948a2d73449114c03c2b8b1c3c20f029f486a6b7"
-    format = "zip"
-
-
-    [resources.sources.update]
-    url = "https://github.com/xech/agora-project/releases/download/25.12/UPDATE_agora-project_25.12.4.zip"
-    sha256 = "de23f0e83ce55960ccaed98be3eeafb756dafc7bad62519b433f7dcfc0a35de8"
-    format = "zip"
-
-
     [resources.system_user]
 
     [resources.install_dir]

--- a/scripts/install
+++ b/scripts/install
@@ -19,8 +19,6 @@ admin_mail=$(ynh_user_get_info --username="$admin" --key=mail)
 ynh_script_progression "Setting up source files..."
 
 ynh_setup_source --dest_dir="$install_dir"
-#ynh_setup_source --source_id=install --dest_dir="$install_dir/app"
-
 
 #=================================================
 # SYSTEM CONFIGURATION

--- a/scripts/install
+++ b/scripts/install
@@ -19,7 +19,7 @@ admin_mail=$(ynh_user_get_info --username="$admin" --key=mail)
 ynh_script_progression "Setting up source files..."
 
 ynh_setup_source --dest_dir="$install_dir"
-ynh_setup_source --source_id=install --dest_dir="$install_dir/app"
+#ynh_setup_source --source_id=install --dest_dir="$install_dir/app"
 
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -15,7 +15,7 @@ ynh_app_setting_set_default --key=php_upload_max_filesize --value=1000M
 ynh_script_progression "Upgrading source files..."
 
 ynh_setup_source --dest_dir="$install_dir" --full_replace --keep="DATAS"
-ynh_setup_source --source_id=update --dest_dir="$install_dir/app"
+#ynh_setup_source --source_id=update --dest_dir="$install_dir/app"
 
 #=================================================
 # REAPPLY SYSTEM CONFIGURATIONS


### PR DESCRIPTION
Afaiu, the patch is no longer required in the v26.2.
BTW, php-intl and php-mbstring are mandatory ; I hadn't notice that in december (I guess they were already installed on my ynh-test...)

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)
